### PR TITLE
Result 타입을 core 패키지로 이동

### DIFF
--- a/src/spooky_town_admin/application/comic_service.clj
+++ b/src/spooky_town_admin/application/comic_service.clj
@@ -4,7 +4,7 @@
    [clojure.tools.logging :as log]
    [spooky-town-admin.domain.comic.errors :as errors]
    [spooky-town-admin.domain.comic.workflow :as workflow]
-   [spooky-town-admin.domain.common.result :as r]
+   [spooky-town-admin.core.result :as r]
    [spooky-town-admin.infrastructure.image-storage :as image-storage]
    [spooky-town-admin.infrastructure.persistence :as persistence]
    [spooky-town-admin.infrastructure.persistence.transaction :refer [with-transaction]]))

--- a/src/spooky_town_admin/core/result.clj
+++ b/src/spooky_town_admin/core/result.clj
@@ -1,0 +1,48 @@
+(ns spooky-town-admin.core.result
+  (:refer-clojure :exclude [map]))  ;; clojure.core의 map과 충돌 방지
+
+(defrecord Result [success value error])
+
+(defn success [value]
+  (->Result true value nil))
+
+(defn failure [error]
+  (->Result false nil error))
+
+(defn success? [result]
+  (:success result))
+
+(defn value [result]
+  (:value result))
+
+(defn error [result]
+  (:error result))
+
+(defn bind [result f]
+  (if (success? result)
+    (f (value result))
+    result))
+
+(defn map [result f]
+  (if (success? result)
+    (success (f (value result)))
+    result))
+
+(defn map-error [result f]
+  (if (success? result)
+    result
+    (failure (f (:error result)))))
+
+(defn to-map [result]
+  (if (success? result)
+    {:success true
+     :value (:value result)}
+    {:success false
+     :error (if (record? (:error result))
+             (into {} (:error result))
+             (:error result))}))
+
+(defn from-map [m]
+  (if (:success m)
+    (success (:value m))
+    (failure (:error m)))) 

--- a/src/spooky_town_admin/domain/comic/types.clj
+++ b/src/spooky_town_admin/domain/comic/types.clj
@@ -5,8 +5,7 @@
                                                   get-validation-message
                                                   validation-error]]
    [spooky-town-admin.domain.comic.errors :as errors]
-   [spooky-town-admin.domain.common.result :refer [failure success]]
-   [spooky-town-admin.domain.common.result :as r]
+   [spooky-town-admin.core.result :as r :refer [failure success]] 
    [clojure.tools.logging :as log]))
 
 ;; --------- 유효성 검사 헬퍼 함수들 ---------

--- a/src/spooky_town_admin/domain/comic/workflow.clj
+++ b/src/spooky_town_admin/domain/comic/workflow.clj
@@ -1,5 +1,5 @@
 (ns spooky-town-admin.domain.comic.workflow
-  (:require [spooky-town-admin.domain.common.result :as r]
+  (:require [spooky-town-admin.core.result :as r]
             [clojure.tools.logging :as log]
             [spooky-town-admin.domain.comic.types :as types]
             [spooky-town-admin.domain.comic.errors :as errors]

--- a/src/spooky_town_admin/infrastructure/config/cloudinary.clj
+++ b/src/spooky_town_admin/infrastructure/config/cloudinary.clj
@@ -1,6 +1,6 @@
 (ns spooky-town-admin.infrastructure.config.cloudinary
   (:require [environ.core :refer [env]]
-            [spooky-town-admin.domain.common.result :as r]
+            [spooky-town-admin.core.result :as r]
             [spooky-town-admin.domain.comic.errors :as errors]
             [clojure.tools.logging :as log])
   (:import [com.cloudinary Cloudinary]

--- a/src/spooky_town_admin/infrastructure/persistence/postgresql.clj
+++ b/src/spooky_town_admin/infrastructure/persistence/postgresql.clj
@@ -6,7 +6,7 @@
    [next.jdbc :as jdbc]
    [next.jdbc.result-set :as rs]
    [spooky-town-admin.domain.comic.errors :as errors]
-   [spooky-town-admin.domain.common.result :as r]
+   [spooky-town-admin.core.result :as r]
    [spooky-town-admin.infrastructure.persistence.config :as config]
    [spooky-town-admin.infrastructure.persistence.protocol :refer [ComicRepository]])
   (:import

--- a/src/spooky_town_admin/infrastructure/persistence/transaction.clj
+++ b/src/spooky_town_admin/infrastructure/persistence/transaction.clj
@@ -1,6 +1,6 @@
 (ns spooky-town-admin.infrastructure.persistence.transaction
   (:require [next.jdbc :as jdbc]
-            [spooky-town-admin.domain.common.result :as r]
+            [spooky-town-admin.core.result :as r]
             [spooky-town-admin.domain.comic.errors :as errors]
             [spooky-town-admin.infrastructure.persistence.config :as config]
             [clojure.tools.logging :as log]))

--- a/src/spooky_town_admin/web/handler.clj
+++ b/src/spooky_town_admin/web/handler.clj
@@ -1,7 +1,7 @@
 (ns spooky-town-admin.web.handler
   (:require
    [spooky-town-admin.application.comic-service :as comic-service]
-   [spooky-town-admin.domain.common.result :as r]
+   [spooky-town-admin.core.result :as r]
    [clojure.tools.logging :as log]))
 
 (defn- handle-result [result]

--- a/test/spooky_town_admin/application/comic_service_test.clj
+++ b/test/spooky_town_admin/application/comic_service_test.clj
@@ -2,13 +2,12 @@
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
    [spooky-town-admin.application.comic-service :as service]
+   [spooky-town-admin.core.result :as r]
    [spooky-town-admin.domain.comic.errors :as errors]
    [spooky-town-admin.domain.comic.workflow :as workflow]
-   [spooky-town-admin.domain.common.result :as r]
    [spooky-town-admin.infrastructure.image-storage :as image-storage]
    [spooky-town-admin.infrastructure.persistence :as persistence]
    [spooky-town-admin.infrastructure.persistence.config :as db-config]
-   [spooky-town-admin.infrastructure.persistence.config :as config]
    [spooky-town-admin.infrastructure.persistence.postgresql :as postgresql])
   (:import
    [java.awt.image BufferedImage]
@@ -62,7 +61,7 @@
         (db-config/run-migrations! {:store :database
                                   :migration-dir "db/migrations"
                                   :db config})
-        (with-redefs [config/get-datasource (constantly ds)  ;; 여기가 변경됨
+        (with-redefs [db-config/get-datasource (constantly ds)  ;; 여기가 변경됨
                      persistence/create-comic-repository 
                      (fn [] (postgresql/->PostgresqlComicRepository ds))
                      image-storage/create-image-storage 

--- a/test/spooky_town_admin/core/result_test.clj
+++ b/test/spooky_town_admin/core/result_test.clj
@@ -1,0 +1,68 @@
+(ns spooky-town-admin.core.result-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [spooky-town-admin.core.result :as r]))
+
+(deftest success-test
+  (testing "success creates successful result"
+    (let [result (r/success 42)]
+      (is (r/success? result))
+      (is (= 42 (r/value result)))
+      (is (nil? (r/error result)))))
+
+  (testing "success with nil value"
+    (let [result (r/success nil)]
+      (is (r/success? result))
+      (is (nil? (r/value result)))
+      (is (nil? (r/error result))))))
+
+(deftest failure-test
+  (testing "failure creates failed result"
+    (let [error {:type :test-error}
+          result (r/failure error)]
+      (is (not (r/success? result)))
+      (is (nil? (r/value result)))
+      (is (= error (r/error result))))))
+
+(deftest bind-test
+  (testing "bind with success"
+    (let [result (-> (r/success 1)
+                     (r/bind #(r/success (inc %))))]
+      (is (r/success? result))
+      (is (= 2 (r/value result)))))
+
+  (testing "bind with failure"
+    (let [error {:type :test-error}
+          result (-> (r/failure error)
+                     (r/bind #(r/success (inc %))))]
+      (is (not (r/success? result)))
+      (is (= error (r/error result))))))
+
+(deftest map-test
+  (testing "map with success"
+    (let [result (-> (r/success 1)
+                     (r/map inc))]
+      (is (r/success? result))
+      (is (= 2 (r/value result)))))
+
+  (testing "map with failure"
+    (let [error {:type :test-error}
+          result (-> (r/failure error)
+                     (r/map inc))]
+      (is (not (r/success? result)))
+      (is (= error (r/error result))))))
+
+(deftest to-map-test
+  (testing "converts success result to map"
+    (let [result (r/success 42)
+          m (r/to-map result)]
+      (is (:success m))
+      (is (= 42 (:value m)))
+      (is (nil? (:error m)))))
+
+  (testing "converts failure result to map"
+    (let [error {:type :test-error}
+          result (r/failure error)
+          m (r/to-map result)]
+      (is (not (:success m)))
+      (is (nil? (:value m)))
+      (is (= error (:error m)))))) 

--- a/test/spooky_town_admin/domain/comic/types_test.clj
+++ b/test/spooky_town_admin/domain/comic/types_test.clj
@@ -1,7 +1,7 @@
 (ns spooky-town-admin.domain.comic.types-test
   (:require [clojure.test :refer [deftest testing is]]
             [spooky-town-admin.domain.comic.types :as types]
-            [spooky-town-admin.domain.common.result :refer [success? success failure]]
+            [spooky-town-admin.core.result :refer [success? success failure]]
             [spooky-town-admin.domain.comic.errors :refer [validation-error]]))
 
 (deftest value-objects-test

--- a/test/spooky_town_admin/domain/comic/workflow_test.clj
+++ b/test/spooky_town_admin/domain/comic/workflow_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
    [spooky-town-admin.domain.comic.workflow :as workflow]
-   [spooky-town-admin.domain.common.result :refer [failure success success?]]
+   [spooky-town-admin.core.result :refer [failure success success?]]
    [spooky-town-admin.infrastructure.image-storage :as image-storage]))
 
 ;; 테스트 데이터

--- a/test/spooky_town_admin/infrastructure/persistence/postgresql_test.clj
+++ b/test/spooky_town_admin/infrastructure/persistence/postgresql_test.clj
@@ -3,7 +3,7 @@
             [next.jdbc :as jdbc]
             [spooky-town-admin.infrastructure.persistence.postgresql :as sut]
             [spooky-town-admin.infrastructure.persistence.protocol :as protocol]
-            [spooky-town-admin.domain.common.result :as r]
+            [spooky-town-admin.core.result :as r]
             [spooky-town-admin.infrastructure.persistence.config :as config])
   (:import [org.testcontainers.containers PostgreSQLContainer]
            [com.zaxxer.hikari HikariConfig HikariDataSource]))


### PR DESCRIPTION
## 변경 사항
- `result.clj`를 domain/common에서 core로 이동
- 도메인 레이어에서 기술적 관심사 분리
- Result 타입에 대한 단위 테스트 추가
- 관련된 모든 파일의 import 문 수정

## 변경 이유
- Result 타입은 도메인 특화 로직이 아닌 범용적인 에러 처리와 결과 랩핑을 위한 것
- 도메인 레이어의 순수성 유지
- 기술적 관심사의 적절한 위치 선정

## 테스트
- Result 타입에 대한 새로운 단위 테스트 추가 및 통과
- 기존 테스트 모두 통과