### PR TITLE
Comic 서비스에 CQRS 패턴 적용

### DIFF
--- a/src/spooky_town_admin/application/comic/command.clj
+++ b/src/spooky_town_admin/application/comic/command.clj
@@ -1,0 +1,29 @@
+(ns spooky-town-admin.application.comic.command
+  (:require
+   [clojure.tools.logging :as log]
+   [spooky-town-admin.domain.comic.errors :as errors]
+   [spooky-town-admin.domain.comic.workflow :as workflow]
+   [spooky-town-admin.core.result :as r]
+   [spooky-town-admin.infrastructure.persistence :as persistence]
+   [spooky-town-admin.infrastructure.persistence.transaction :refer [with-transaction]]))
+
+(defn- check-duplicate-isbn [comic-repository comic-data]
+  (log/debug "Checking duplicate ISBN for:" comic-data)
+  (let [isbn (or (:isbn13 comic-data) (:isbn10 comic-data))
+        result (persistence/find-comic-by-isbn comic-repository isbn)]
+    (if (and (r/success? result) 
+             (some? (r/value result)))
+      (do
+        (log/info "Duplicate ISBN found")
+        (r/failure (errors/business-error
+                    :duplicate-isbn
+                    (errors/get-business-message :duplicate-isbn))))
+      (r/success comic-data))))
+
+(defn create-comic [{:keys [comic-repository image-storage] :as service} comic-data]
+  (with-transaction
+    (log/debug "Transaction started" (pr-str comic-data))
+    (-> (check-duplicate-isbn comic-repository comic-data)
+        (r/bind #(workflow/create-comic-workflow image-storage %))
+        (r/bind (fn [{:keys [comic]}]
+                  (persistence/save-comic comic-repository comic)))))) 

--- a/src/spooky_town_admin/application/comic/query.clj
+++ b/src/spooky_town_admin/application/comic/query.clj
@@ -1,0 +1,19 @@
+(ns spooky-town-admin.application.comic.query
+  (:require
+   [spooky-town-admin.domain.comic.errors :as errors]
+   [spooky-town-admin.core.result :as r]
+   [spooky-town-admin.infrastructure.persistence :as persistence]))
+
+(defn get-comic [{:keys [comic-repository]} id]
+  (-> (if-let [comic (persistence/find-comic-by-id comic-repository id)]
+        (r/success comic)
+        (r/failure (errors/business-error :not-found 
+                                        (errors/get-business-message :not-found))))
+      (r/map #(select-keys % [:id :title :artist :author :isbn13 :isbn10]))
+      r/to-map))
+
+(defn list-comics [{:keys [comic-repository]}]
+  (let [comics (persistence/list-comics comic-repository)]
+    {:success true
+     :comics (map #(select-keys % [:id :title :artist :author :isbn13 :isbn10])
+                  comics)})) 

--- a/src/spooky_town_admin/application/comic/service.clj
+++ b/src/spooky_town_admin/application/comic/service.clj
@@ -1,0 +1,11 @@
+(ns spooky-town-admin.application.comic.service
+  (:require
+   [spooky-town-admin.infrastructure.image-storage :as image-storage]
+   [spooky-town-admin.infrastructure.persistence :as persistence]))
+
+(defrecord ComicService [comic-repository image-storage])
+
+(defn create-comic-service [env]
+  (->ComicService 
+   (persistence/create-comic-repository)
+   (image-storage/create-image-storage env))) 

--- a/src/spooky_town_admin/web/handler.clj
+++ b/src/spooky_town_admin/web/handler.clj
@@ -1,6 +1,7 @@
 (ns spooky-town-admin.web.handler
   (:require
-   [spooky-town-admin.application.comic-service :as comic-service]
+   [spooky-town-admin.application.comic.command :as comic-command]
+   [spooky-town-admin.application.comic.query :as comic-query]
    [spooky-town-admin.core.result :as r]
    [clojure.tools.logging :as log]))
 
@@ -21,7 +22,7 @@
 
 (defn list-comics [service]
   (try
-    (let [result (comic-service/list-comics service)]
+    (let [result (comic-query/list-comics service)]
       (handle-result result))
     (catch Exception e
       {:status 500
@@ -31,7 +32,7 @@
 (defn get-comic-by-id [service id]
   (try
     (let [comic-id (Integer/parseInt id)
-          result (comic-service/get-comic service comic-id)]
+          result (comic-query/get-comic service comic-id)]
       (handle-result result))
     (catch NumberFormatException _
       {:status 400
@@ -51,7 +52,7 @@
         {:status 400
          :body {:error :validation
                 :message "요청 본문이 비어있습니다."}})
-      (let [result (comic-service/create-comic service body-params)]
+      (let [result (comic-command/create-comic service body-params)]
         (if (r/success? result)
           {:status 201
            :body (:value result)}

--- a/test/spooky_town_admin/application/comic/query_test.clj
+++ b/test/spooky_town_admin/application/comic/query_test.clj
@@ -1,0 +1,86 @@
+(ns spooky-town-admin.application.comic.query-test
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [spooky-town-admin.application.comic.command :as command]
+   [spooky-town-admin.application.comic.query :as query]
+   [spooky-town-admin.application.comic.service :as service]
+   [spooky-town-admin.core.result :as r]
+   [spooky-town-admin.infrastructure.persistence :as persistence]
+   [spooky-town-admin.infrastructure.persistence.config :as db-config]
+   [spooky-town-admin.infrastructure.persistence.postgresql :as postgresql]
+   )
+  (:import
+   [org.testcontainers.containers PostgreSQLContainer]))
+
+;; TestContainers를 위한 설정
+(defn create-test-container []
+  (doto (PostgreSQLContainer. "postgres:16")
+    (.withDatabaseName "test_db")
+    (.withUsername "test")
+    (.withPassword "test")))
+
+;; 테스트 픽스처
+(def ^:dynamic *test-datasource* nil)
+
+(def test-comic-data
+  {:title "테스트 만화"
+   :artist "테스트 작가"
+   :author "테스트 글작가"
+   :isbn13 "9791163243021"
+   :isbn10 "1163243027"
+   :publisher "테스트 출판사"
+   :price 15000})
+
+(defn test-fixture [f]
+  (let [container (create-test-container)]
+    (try
+      (.start container)
+      (let [config {:dbtype "postgresql"
+                   :dbname (.getDatabaseName container)
+                   :host "localhost"
+                   :port (.getMappedPort container 5432)
+                   :user (.getUsername container)
+                   :password (.getPassword container)}
+            ds (db-config/create-datasource config)]
+        (println "Created test datasource")
+        (db-config/run-migrations! {:store :database
+                                  :migration-dir "db/migrations"
+                                  :db config})
+        (with-redefs [db-config/get-datasource (constantly ds)
+                     persistence/create-comic-repository 
+                     (fn [] (postgresql/->PostgresqlComicRepository ds))]
+          ;; 테스트 데이터 생성
+          (let [service (service/create-comic-service {})
+                result (command/create-comic service test-comic-data)]
+            (when-not (r/success? result)
+              (throw (ex-info "Failed to create test data" {:error (:error result)}))))
+          (f)))
+      (finally
+        (.stop container)))))
+
+(use-fixtures :each test-fixture)
+
+(deftest get-comic-test
+  (testing "만화 조회 - 성공 케이스"
+    (let [service (service/create-comic-service {})
+          comic-id 1
+          result (query/get-comic service comic-id)]
+      (is (r/success? result))
+      (is (= comic-id (:id (r/value result))))
+      (is (= "테스트 만화" (:title (r/value result))))))
+
+  (testing "만화 조회 - 실패 케이스"
+    (let [service (service/create-comic-service {})
+          comic-id 9999
+          result (query/get-comic service comic-id)]
+      (is (not (r/success? result)))
+      (is (= :not-found (:code (:error result)))))))
+
+(deftest list-comics-test
+  (testing "만화 목록 조회"
+    (let [service (service/create-comic-service {})
+          result (query/list-comics service)]
+      (is (r/success? result))
+      (let [comics (r/value result)]
+        (is (seq comics))
+        (is (= "테스트 만화" (:title (first comics)))))))) 


### PR DESCRIPTION
# Comic 서비스에 CQRS 패턴 적용

## 변경사항
- Comic 서비스를 Command와 Query로 분리
  - `command.clj`: 만화 생성 관련 로직
  - `query.clj`: 만화 조회 관련 로직
- 테스트 코드도 각각 분리하여 재구성
  - `command_test.clj`: 만화 생성 관련 테스트
  - `query_test.clj`: 만화 조회 관련 테스트
- 테스트 데이터 생성 로직 개선

## 테스트
- 모든 테스트 통과 확인
- TestContainers를 사용한 통합 테스트 유지